### PR TITLE
Fixes mapmerge python path

### DIFF
--- a/tools/mapmerge2/mapmerge.bat
+++ b/tools/mapmerge2/mapmerge.bat
@@ -1,5 +1,5 @@
 @echo off
 set MAPROOT=../../_maps/
 set TGM=1
-python3 mapmerge.py
+python mapmerge.py
 pause


### PR DESCRIPTION
## About The Pull Request
When I added DMAPI, I staged all because it was 50 file changes. I didnt realise I staged `tools/mapmerge2/mapmerge.bat`, which I had modified because of my python path, and probably made it invalid for anyone else using it

## Why It's Good For The Game
Being able to merge maps properly is kind of important

## Changelog
:cl: AffectedArc07
fix: Mapmerge works on 99% of systems again
/:cl:
