### PR TITLE
Fix undeleted queries

### DIFF
--- a/modular_citadel/code/modules/mentor/mentor.dm
+++ b/modular_citadel/code/modules/mentor/mentor.dm
@@ -85,6 +85,7 @@ GLOBAL_PROTECT(mentor_href_token)
 		while(query_load_mentors.NextRow())
 			var/ckey = ckey(query_load_mentors.item[1])
 			new /datum/mentors(ckey)
+		qdel(query_load_mentors)
 
 // new client var: mentor_datum. Acts the same way holder does towards admin: it holds the mentor datum. if set, the guy's a mentor.
 /client

--- a/modular_citadel/code/modules/mentor/mentor_memo.dm
+++ b/modular_citadel/code/modules/mentor/mentor_memo.dm
@@ -50,6 +50,8 @@
 				return
 			log_admin("[key_name(src)] has set a mentor memo: [memotext]")
 			message_admins("[key_name_admin(src)] has set a mentor memo:<br>[memotext]")
+			qdel(query_memocheck)
+			qdel(query_memoadd)
 		if("Edit")
 			var/datum/DBQuery/query_memolist = SSdbcore.NewQuery("SELECT ckey FROM [format_table_name("mentor_memo")]")
 			if(!query_memolist.Execute())
@@ -91,6 +93,9 @@
 				else
 					log_admin("[key_name(src)] has edited [target_sql_ckey]'s mentor memo from [old_memo] to [new_memo]")
 					message_admins("[key_name_admin(src)] has edited [target_sql_ckey]'s mentor memo from<br>[old_memo]<br>to<br>[new_memo]")
+				qdel(update_query)
+			qdel(query_memolist)
+			qdel(query_memofind)
 		if("Show")
 			var/datum/DBQuery/query_memoshow = SSdbcore.NewQuery("SELECT ckey, memotext, timestamp, last_editor FROM [format_table_name("mentor_memo")]")
 			if(!query_memoshow.Execute())
@@ -111,6 +116,7 @@
 				to_chat(src, "No memos found in database.")
 				return
 			to_chat(src, output)
+			qdel(query_memoshow)
 		if("Remove")
 			var/datum/DBQuery/query_memodellist = SSdbcore.NewQuery("SELECT ckey FROM [format_table_name("mentor_memo")]")
 			if(!query_memodellist.Execute())
@@ -139,3 +145,5 @@
 			else
 				log_admin("[key_name(src)] has removed [target_sql_ckey]'s mentor memo.")
 				message_admins("[key_name_admin(src)] has removed [target_sql_ckey]'s mentor memo.")
+			qdel(query_memodellist)
+			qdel(query_memodel)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR fixes the issue of SQL queries going undeleted. It also stops these logs appearing
```
[2019-06-25 19:09:40.299] SQL: Undeleted query: "SELECT ckey FROM mentor" LA: NextRow LAT: 0.5
[2019-06-25 19:09:40.300] SQL: Undeleted query: "SELECT ckey, memotext, timestamp, last_editor FROM mentor_memo" LA: NextRow LAT: 115.5
[2019-06-25 19:09:40.301] SQL: Undeleted query: "SELECT ckey, memotext, timestamp, last_editor FROM mentor_memo" LA: NextRow LAT: 181
```
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It fixes issues and stops us being spammed
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: SQL queries properly delete now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
