### PR TITLE
Crispy Status Displays

### DIFF
--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -1,7 +1,7 @@
 #define CHARS_PER_LINE 5
 #define FONT_SIZE "5pt"
 #define FONT_COLOR "#09f"
-#define FONT_STYLE "Arial Black"
+#define FONT_STYLE "Small Fonts"
 #define MAX_TIMER 9000
 
 #define PRESET_SHORT 1200
@@ -36,6 +36,7 @@
 
 	maptext_height = 26
 	maptext_width = 32
+	maptext_y = -1 // This font is a tall boy
 
 /obj/machinery/door_timer/Initialize()
 	. = ..()
@@ -168,7 +169,7 @@
 	if(timing)
 		var/disp1 = id
 		var/time_left = time_left(seconds = TRUE)
-		var/disp2 = "[add_zero(num2text((time_left / 60) % 60),2)]~[add_zero(num2text(time_left % 60), 2)]"
+		var/disp2 = "[add_zero(num2text((time_left / 60) % 60),2)]:[add_zero(num2text(time_left % 60), 2)]"
 		if(length(disp2) > CHARS_PER_LINE)
 			disp2 = "Error"
 		update_display(disp1, disp2)
@@ -189,6 +190,8 @@
 //Checks to see if there's 1 line or 2, adds text-icons-numbers/letters over display
 // Stolen from status_display
 /obj/machinery/door_timer/proc/update_display(line1, line2)
+	line1 = uppertext(line1) // Uppercase because the font is unreadable in small
+	line2 = uppertext(line2) // Uppercase because the font is unreadable in small
 	var/new_text = {"<div style="font-size:[FONT_SIZE];color:[FONT_COLOR];font:'[FONT_STYLE]';text-align:center;" valign="top">[line1]<br>[line2]</div>"}
 	if(maptext != new_text)
 		maptext = new_text

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -4,7 +4,7 @@
 #define CHARS_PER_LINE 5
 #define FONT_SIZE "5pt"
 #define FONT_COLOR "#09f"
-#define FONT_STYLE "Arial Black"
+#define FONT_STYLE "Small Fonts"
 #define SCROLL_SPEED 2
 
 #define SD_BLANK 0  // 0 = Blank
@@ -27,6 +27,7 @@
 
 	maptext_height = 26
 	maptext_width = 32
+	maptext_y  = -1
 
 	var/message1 = ""	// message line 1
 	var/message2 = ""	// message line 2
@@ -46,6 +47,8 @@
 
 /// Immediately change the display to the given two lines.
 /obj/machinery/status_display/proc/update_display(line1, line2)
+	line1 = uppertext(line1) // Uppercase because the font is unreadable in small
+	line2 = uppertext(line2) // Uppercase because the font is unreadable in small
 	var/new_text = {"<div style="font-size:[FONT_SIZE];color:[FONT_COLOR];font:'[FONT_STYLE]';text-align:center;" valign="top">[line1]<br>[line2]</div>"}
 	if(maptext != new_text)
 		maptext = new_text


### PR DESCRIPTION
## About The Pull Request
This PR changes our status displays to use a more readable font, that has been present on all versions of windows since Vista.
![image](https://user-images.githubusercontent.com/25063394/60252895-ff8cb680-98c2-11e9-828b-cbee19d8266f.png)
![image](https://user-images.githubusercontent.com/25063394/60252907-06b3c480-98c3-11e9-8edf-b9cb02b16f7f.png)

## Why It's Good For The Game
Status displays are supposed to be readable, and they really arent at the moment

## Changelog
:cl:
tweak: Status displays have been updated. Mmmmm crispy....
/:cl:
