### PR TITLE
Makes "me" a small box

### DIFF
--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -20,7 +20,7 @@
 /mob/proc/whisper(message, datum/language/language=null)
 	say(message, language) //only living mobs actually whisper, everything else just talks
 
-/mob/verb/me_verb(message as message)
+/mob/verb/me_verb(message as text)
 	set name = "Me"
 	set category = "IC"
 


### PR DESCRIPTION
## About The Pull Request
This changes the box for the verb `me` back to a single line textbox instead of a multiline

## Why It's Good For The Game
I would rather pressing enter to send a message instead of having to tab across to the send button. We dont need multi-line emotes here

## Changelog
:cl:
tweak: The "me" verb is now a single line textbox again
/:cl:
