### PR TITLE
Removes bad random events

### DIFF
--- a/code/modules/events/aurora_caelus.dm
+++ b/code/modules/events/aurora_caelus.dm
@@ -1,3 +1,7 @@
+/*
+This is disabled
+Reason: This event destroys the ping of any server its ran on, and is in need of a rework
+
 /datum/round_event_control/aurora_caelus
 	name = "Aurora Caelus"
 	typepath = /datum/round_event/aurora_caelus
@@ -60,3 +64,4 @@
 		S.set_light(S.light_range - 0.2)
 		sleep(30)
 	S.set_light(new_light, initial(S.light_power), initial(S.light_color))
+*/

--- a/code/modules/events/false_alarm.dm
+++ b/code/modules/events/false_alarm.dm
@@ -1,3 +1,7 @@
+/*
+This is disabled
+Reason: Fuck these events. They make everyone think theres a major issue, and is extremely disrupting for no reason at all
+
 /datum/round_event_control/falsealarm
 	name 			= "False Alarm"
 	typepath 		= /datum/round_event/falsealarm
@@ -60,3 +64,4 @@
 		if(!initial(event.fakeable))
 			continue
 		. += E
+*/


### PR DESCRIPTION
## About The Pull Request
This PR removes the aurora caelus random event, as well as the false alarm events, with different reasons for each

Reason for removing aurora caelus: It absolutely destroys the server and is terribly coded (It does the same on other servers, tripling the ping for most users)

Reason for removing false alarms: They cause too much distress in the round for no reason at all. You get a false alarm for a blob and everyone instantly stops what they are doing, just to realise it was all for nothing

## Why It's Good For The Game
Lag bad, fake alerts bad

## Changelog
:cl: AffectedArc07
del: Removed aurora caelus and false alarm random events
/:cl:

