### PR TITLE
Makes new player panel bigger

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -75,7 +75,7 @@
 	output += "</center>"
 
 	//src << browse(output,"window=playersetup;size=210x240;can_close=0")
-	var/datum/browser/popup = new(src, "playersetup", "<div align='center'>New Player Options</div>", 250, 265)
+	var/datum/browser/popup = new(src, "playersetup", "<div align='center'>New Player Options</div>", 250, 300)
 	popup.set_window_options("can_close=0")
 	popup.set_content(output)
 	popup.open(0)


### PR DESCRIPTION
## About The Pull Request
This PR increases the vertical size of the new player box
![image](https://user-images.githubusercontent.com/25063394/60757136-99104280-9ffe-11e9-8145-962902fb6646.png)
The reasoning for this is after adding the TOS button, you had to scroll to fit all the UI elements in, which looked **very** bad.

## Why It's Good For The Game
You should be able to not have to scroll in a box that takes up like 1/16th of your screen

## Changelog
:cl: AffectedArc07
fix: The lobby options box now comfortably fits the buttons without having to scroll
/:cl:
