### PR TITLE
Changes radio colors to paras

### DIFF
--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -274,19 +274,19 @@ em						{font-style: normal;	font-weight: bold;}
 .binarysay    			{color: #20c20e; background-color: #000000; display: block;}
 .binarysay a  			{color: #00ff00;}
 .binarysay a:active, .binarysay a:visited {color: #88ff88;}
-.radio					{color: #008000;}
+.radio					{color: #408010;}
 .sciradio				{color: #993399;}
-.comradio				{color: #948f02;}
-.secradio				{color: #a30000;}
-.medradio				{color: #337296;}
-.engradio				{color: #fb5613;}
-.suppradio				{color: #a8732b;}
-.servradio				{color: #6eaa2c;}
-.syndradio				{color: #6d3f40;}
+.comradio				{color: #204090;}
+.secradio				{color: #A30000;}
+.medradio				{color: #009190;}
+.engradio				{color: #A66300;}
+.suppradio				{color: #7F6539;}
+.servradio				{color: #80A000;}
+.syndradio				{color: #6D3F40;}
 .centcomradio			{color: #686868;}
-.aiprivradio			{color: #ff00ff;}
-.redteamradio           {color: #ff0000;}
-.blueteamradio          {color: #0000ff;}
+.aiprivradio			{color: #F00FFF;}
+.redteamradio           {color: #FF0000;}
+.blueteamradio          {color: #0000FF;}
 
 .yell					{					font-weight: bold;}
 

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -35,23 +35,23 @@ em						{font-style: normal;	font-weight: bold;}
 .name					{					font-weight: bold;}
 
 .say					{}
-.deadsay				{color: #5c00e6;}
+.deadsay				{color: #5C00E6;}
 .binarysay    			{color: #20c20e; background-color: #000000; display: block;}
 .binarysay a  			{color: #00ff00;}
 .binarysay a:active, .binarysay a:visited {color: #88ff88;}
-.radio					{color: #008000;}
+.radio					{color: #408010;}
 .sciradio				{color: #993399;}
-.comradio				{color: #948f02;}
-.secradio				{color: #a30000;}
-.medradio				{color: #337296;}
-.engradio				{color: #fb5613;}
-.suppradio				{color: #a8732b;}
-.servradio				{color: #6eaa2c;}
-.syndradio				{color: #6d3f40;}
+.comradio				{color: #204090;}
+.secradio				{color: #A30000;}
+.medradio				{color: #009190;}
+.engradio				{color: #A66300;}
+.suppradio				{color: #7F6539;}
+.servradio				{color: #80A000;}
+.syndradio				{color: #6D3F40;}
 .centcomradio			{color: #686868;}
-.aiprivradio			{color: #ff00ff;}
-.redteamradio           {color: #ff0000;}
-.blueteamradio          {color: #0000ff;}
+.aiprivradio			{color: #F00FFF;}
+.redteamradio           {color: #FF0000;}
+.blueteamradio          {color: #0000FF;}
 
 .yell					{					font-weight: bold;}
 


### PR DESCRIPTION
## About The Pull Request
This PR changes our radio colors to be inline with paras. Examples are below
![image](https://user-images.githubusercontent.com/25063394/60757500-9401c200-a003-11e9-91b0-6e994e64b8e5.png)

## Why It's Good For The Game
It matches department colors better (Colors on the headsets, doors, etc). Also why the hell is command an awful yellow-green color on TG code anyways?

## Changelog
:cl:
tweak: Department radio colors are now the same as Paradise
/:cl:
