### PR TITLE
End-Round Log Parsing

### DIFF
--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -261,3 +261,21 @@
 		return "([AREACOORD(T)])"
 	else if(A.loc)
 		return "(UNKNOWN (?, ?, ?))"
+
+/* KEPLER CHANGE: Parse all server logs to remove data such as IPs and CIDs. */
+/proc/parse_server_logs()
+	if(IsAdminAdvancedProcCall())
+		to_chat(usr, "<span class='notice'><b>ERROR:</b> This proc can only be called by the server on restart.</span>")
+		return
+	if(!CONFIG_GET(flag/logparse_enable))
+		return // Kill this ASAP if its not enabled so world can reboot
+	if(!CONFIG_GET(string/logparse_parser_executable))
+		return // Kill this ASAP if its missing args so world can reboot
+	if(!CONFIG_GET(string/logparse_server_basedir))
+		return // Kill this ASAP if its missing args so world can reboot
+	if(!CONFIG_GET(string/logparse_output_dir))
+		return // Kill this ASAP if its missing args so world can reboot
+	
+	var/command = "\"[CONFIG_GET(string/logparse_parser_executable)]\" \"[CONFIG_GET(string/logparse_server_basedir)]/[GLOB.log_directory]\" \"[CONFIG_GET(string/logparse_output_dir)]\""
+	// Command will do something like this: "C:/path/to/LogParser.exe" "C:/server/root/data/logs/2019/07/12/round-13.46.45" "C:/Logs/Output" 
+	shell(command)

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -232,6 +232,7 @@ GLOBAL_VAR(restart_counter)
 
 	log_world("World rebooted at [TIME_STAMP("hh:mm:ss", FALSE)]")
 	shutdown_logging() // Past this point, no logging procs can be used, at risk of data loss.
+	parse_server_logs() // KEPLER CHANGE - If logs have been closed, parse them now
 	..()
 
 /world/proc/update_status()

--- a/config/config.txt
+++ b/config/config.txt
@@ -468,3 +468,26 @@ DISABLE_HIGH_POP_MC_MODE_AMOUNT 60
 ##	For reference, Goonstation uses a resolution of 21x15 for it's widescreen mode.
 ##	Do note that changing this value will affect the title screen. The title screen will have to be updated manually if this is changed.
 DEFAULT_VIEW 21x15
+
+#######################################
+# Automatic Log Parsing Configuration #
+#######################################
+## If you have an external script to parse game logs, configure it here. If not, do not configure anything here, as it will cause unnecassary shell() calls
+## Not only will this halt execution since shell() is blocking, but incorrectly configuring shell calls can cause unintended behaviour
+## Do NOT include speech marks in paths, the code has them in place properly
+## Do NOT use \, you MUST use / to avoid weird escape issues
+## YOU HAVE BEEN WARNED
+
+
+## Uncomment to end-round log parsing
+#LOGPARSE_ENABLE
+
+## Uncomment and put the ABSOLUTE PATH to your logparse exectuable (C:/Extra Programs/LogParser/LogParser.exe)
+#LOGPARSE_PARSER_EXECUTABLE C:/Path/To/LogParser.exe
+
+## Uncomment and put the ABSOLUTE PATH to your servers static config directory (data/logs will be appended after).
+## YOU MUST NOT PUT A TRAILING / ON THE END!!!!!!!!!!!
+#LOGPARSE_SERVER_BASEDIR C:/Server/Basepath
+
+## Uncomment and put the ABSOLUTE PATH to the directory where you want your server logs to end up
+#LOGPARSE_OUTPUT_DIR C:/Website/Logs

--- a/modular_kepler/code/controllers/configuration/entries/general.dm
+++ b/modular_kepler/code/controllers/configuration/entries/general.dm
@@ -1,0 +1,15 @@
+// Is logparsing enabled
+/datum/config_entry/flag/logparse_enable
+	config_entry_value = 0
+
+// Where is the parser
+/datum/config_entry/string/logparse_parser_executable
+	config_entry_value = ""
+
+// Where is the server
+/datum/config_entry/string/logparse_server_basedir
+	config_entry_value = ""
+
+// Where do we want parsed data
+/datum/config_entry/string/logparse_output_dir
+	config_entry_value = ""

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3003,6 +3003,7 @@
 #include "modular_citadel\code\modules\research\techweb\all_nodes.dm"
 #include "modular_citadel\code\modules\research\xenobiology\xenobio_camera.dm"
 #include "modular_citadel\code\modules\vehicles\secway.dm"
+#include "modular_kepler\code\controllers\configuration\entries\general.dm"
 #include "modular_kepler\code\game\objects\ids.dm"
 #include "modular_kepler\code\game\objects\items\cards_ids.dm"
 #include "modular_kepler\code\modules\client\preferences.dm"


### PR DESCRIPTION
## About The Pull Request
This PR adds in the necassary hooks for calling log-parsing at the end of each round. The issue with our current parser system is it fires off every hour, which has some issues, including but not limited to:
- Logs can take up to a full hour to appear on the site
- Logs from the current round may be published, allowing for metagaming
- Logs can be published half complete due to ongoing rounds, which wont get updated

This PR will call the logparser with configurable dirs at end round, after everyone has been moved off the server, and after logging has been shut down, to ensure were on the absolute final log files

In terms of why I am calling it so late, this is why:
- I want it called after logs have closed, to make sure we are on definite latest
- The `shell()` function is blocking, meaning it halts operation while running, obviously this cant be called mid round without issues
- It makes sense to call it late, thus why youre not allowed to call it with Advanced ProcCall

## Why It's Good For The Game
Having accurate logs is a necessity to be GDPR compliant, and it stops me running a background process that I will forget to start next time my UPS shits itself

## Changelog
:cl:
server: You can now configure log-parsing to go off at the end of each round
/:cl:
