### PR TITLE
Increases Upload Limit

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1,7 +1,8 @@
 	////////////
 	//SECURITY//
 	////////////
-#define UPLOAD_LIMIT		1048576	//Restricts client uploads to the server to 1MB //Could probably do with being lower.
+#define UPLOAD_LIMIT		10485760	// Restricts client uploads to the server to 10MB Could probably do with being lower.
+										// KEPLER CHANGE: No this does not need to be lower. This thing used to be 1mb and that is fuck all
 
 GLOBAL_LIST_INIT(blacklisted_builds, list(
 	"1407" = "bug preventing client display overrides from working leads to clients being able to see things/mobs they shouldn't be able to see",


### PR DESCRIPTION
## About The Pull Request
This PR Increases our upload limit from 1MB to 10MB, because 1MB is far too small to do anything with, without brutally compressing the audio (Apologies to the ears of @CornMyCob and JT)

## Why It's Good For The Game
Bigger file uploads are better, and people want to hear audio that isnt at 8khz

## Changelog
:cl: AffectedArc07
tweak: Admins can now upload MIDIs and sound files larger than 1MB (Cap is 10MB)
/:cl:

