### PR TITLE
Fixes PDA cart menus

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -262,7 +262,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 				dat += "<li>[PDAIMG(notes)]<a href='byond://?src=[REF(src)];choice=41'>View Crew Manifest</a></li>"
 				dat += "</ul>"
 
-				if (cartridge)
+				if (cartridge && cartridge.has_menus)
 					dat += "<h4>Cartridge Functions</h4><ul>"
 					if (cartridge.access & CART_JANITOR)
 						dat += "<li>[PDAIMG(bucket)]<a href='byond://?src=[REF(src)];choice=49'>Custodial Locator</a></li>"
@@ -271,25 +271,16 @@ GLOBAL_LIST_EMPTY(PDAs)
 						dat += "<li>[PDAIMG(honk)]<a href='byond://?src=[REF(src)];choice=Trombone'>Sad Trombone</a></li>"						
 					if(cartridge.access & CART_STATUS_DISPLAY)
 						dat += "<li>[PDAIMG(status)]<a href='byond://?src=[REF(src)];choice=42'>Set Status Display</a></li>"
-					dat += "</ul>"
 					if (cartridge.access & CART_ENGINE)
-						dat += "<ul>"
 						dat += "<li>[PDAIMG(power)]<a href='byond://?src=[REF(src)];choice=43'>Power Monitor</a></li>"
-						dat += "</ul>"
 					if (cartridge.access & CART_MEDICAL)
-						dat += "<ul>"
 						dat += "<li>[PDAIMG(medical)]<a href='byond://?src=[REF(src)];choice=44'>Medical Records</a></li>"
 						dat += "<li>[PDAIMG(scanner)]<a href='byond://?src=[REF(src)];choice=Medical Scan'>[scanmode == 1 ? "Disable" : "Enable"] Medical Scanner</a></li>"
-						dat += "</ul>"
 					if (cartridge.access & CART_SECURITY)
-						dat += "<ul>"
 						dat += "<li>[PDAIMG(cuffs)]<a href='byond://?src=[REF(src)];choice=45'>Security Records</A></li>"
-						dat += "</ul>"
 					if(cartridge.access & CART_QUARTERMASTER)
-						dat += "<ul>"
 						dat += "<li>[PDAIMG(crate)]<a href='byond://?src=[REF(src)];choice=47'>Supply Records</A></li>"
 						dat += "<li>[PDAIMG(crate)]<a href='byond://?src=[REF(src)];choice=48'>Ore Silo Logs</a></li>"
-						dat += "</ul>"
 					dat += "</ul>"
 
 				dat += "<h4>Utilities</h4>"

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -48,6 +48,7 @@
 
 	var/mob/living/simple_animal/bot/active_bot
 	var/list/botlist = list()
+	var/has_menus = FALSE
 
 /obj/item/cartridge/Initialize()
 	. = ..()
@@ -60,6 +61,7 @@
 	icon_state = "cart-e"
 	access = CART_ENGINE | CART_DRONEPHONE
 	bot_access_flags = FLOOR_BOT
+	has_menus = TRUE
 
 /obj/item/cartridge/atmos
 	name = "\improper BreatheDeep cartridge"
@@ -72,6 +74,7 @@
 	icon_state = "cart-m"
 	access = CART_MEDICAL
 	bot_access_flags = MED_BOT
+	has_menus = TRUE
 
 /obj/item/cartridge/chemistry
 	name = "\improper ChemWhiz cartridge"
@@ -84,12 +87,14 @@
 	icon_state = "cart-s"
 	access = CART_SECURITY
 	bot_access_flags = SEC_BOT
+	has_menus = TRUE
 
 /obj/item/cartridge/detective
 	name = "\improper D.E.T.E.C.T. cartridge"
 	icon_state = "cart-eye"
 	access = CART_SECURITY | CART_MEDICAL
 	bot_access_flags = SEC_BOT
+	has_menus = TRUE
 
 /obj/item/cartridge/janitor
 	name = "\improper CustodiPRO cartridge"
@@ -97,12 +102,14 @@
 	icon_state = "cart-j"
 	access = CART_JANITOR | CART_DRONEPHONE
 	bot_access_flags = CLEAN_BOT
+	has_menus = TRUE
 
 /obj/item/cartridge/lawyer
 	name = "\improper P.R.O.V.E. cartridge"
 	icon_state = "cart-law"
 	access = CART_SECURITY
 	spam_enabled = 1
+	has_menus = TRUE
 
 /* Doesnt work, no idea why
 /obj/item/cartridge/curator
@@ -140,23 +147,27 @@
 	icon_state = "cart-q"
 	access = CART_QUARTERMASTER
 	bot_access_flags = MULE_BOT
+	has_menus = TRUE
 
 /obj/item/cartridge/head
 	name = "\improper Easy-Record DELUXE cartridge"
 	icon_state = "cart-h"
 	access = CART_STATUS_DISPLAY
+	has_menus = TRUE
 
 /obj/item/cartridge/hop
 	name = "\improper HumanResources9001 cartridge"
 	icon_state = "cart-h"
 	access = CART_STATUS_DISPLAY | CART_JANITOR | CART_SECURITY | CART_QUARTERMASTER | CART_DRONEPHONE
 	bot_access_flags = MULE_BOT | CLEAN_BOT
+	has_menus = TRUE
 
 /obj/item/cartridge/hos
 	name = "\improper R.O.B.U.S.T. DELUXE cartridge"
 	icon_state = "cart-hos"
 	access = CART_STATUS_DISPLAY | CART_SECURITY
 	bot_access_flags = SEC_BOT
+	has_menus = TRUE
 
 
 /obj/item/cartridge/ce
@@ -164,18 +175,21 @@
 	icon_state = "cart-ce"
 	access = CART_STATUS_DISPLAY | CART_ENGINE | CART_ATMOS | CART_DRONEPHONE
 	bot_access_flags = FLOOR_BOT | FIRE_BOT
+	has_menus = TRUE
 
 /obj/item/cartridge/cmo
 	name = "\improper Med-U DELUXE cartridge"
 	icon_state = "cart-cmo"
 	access = CART_STATUS_DISPLAY | CART_REAGENT_SCANNER | CART_MEDICAL
 	bot_access_flags = MED_BOT
+	has_menus = TRUE
 
 /obj/item/cartridge/rd
 	name = "\improper Signal Ace DELUXE cartridge"
 	icon_state = "cart-rd"
 	access = CART_STATUS_DISPLAY | CART_REAGENT_SCANNER | CART_ATMOS | CART_DRONEPHONE
 	bot_access_flags = FLOOR_BOT | CLEAN_BOT | MED_BOT | FIRE_BOT
+	has_menus = TRUE
 
 /obj/item/cartridge/rd/Initialize()
 	. = ..()
@@ -188,6 +202,7 @@
 	access = ~(CART_CLOWN | CART_MIME | CART_REMOTE_DOOR)
 	bot_access_flags = SEC_BOT | MULE_BOT | FLOOR_BOT | CLEAN_BOT | MED_BOT | FIRE_BOT
 	spam_enabled = 1
+	has_menus = TRUE
 
 /obj/item/cartridge/captain/New()
 	..()


### PR DESCRIPTION
## About The Pull Request
This PR fixes the weird issues some PDA carts had, when they had functions but didn't have any menus, it would show a `Cartridge Functions` header but have no options. Also cleans up the menu and spaces things a little better

Fixes #258 

## Why It's Good For The Game
Makes menus look better and not crappy

## Changelog
:cl: AffectedArc07
fix: PDA will now only show cartridge functions if your cartridge has functions
/:cl: