### PR TITLE
shuttle changes

### DIFF
--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -204,9 +204,9 @@
 		var/security_num = seclevel2num(get_security_level())
 		switch(security_num)
 			if(SEC_LEVEL_GREEN)
-				set_coefficient = 2
+				set_coefficient = 1
 			if(SEC_LEVEL_BLUE)
-				set_coefficient = 1.2
+				set_coefficient = 1
 			if(SEC_LEVEL_AMBER)
 				set_coefficient = 0.8
 			else

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -204,7 +204,7 @@
 		var/security_num = seclevel2num(get_security_level())
 		switch(security_num)
 			if(SEC_LEVEL_GREEN)
-				set_coefficient = 1
+				set_coefficient = 1.2
 			if(SEC_LEVEL_BLUE)
 				set_coefficient = 1
 			if(SEC_LEVEL_AMBER)


### PR DESCRIPTION
## About The Pull Request

This PR changes the green and blue alert shuttles from 20 and 12 minutes both to 10 minutes.

## Why It's Good For The Game

20 minutes is a long time.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Green and blue alert shuttles now take just 10 minutes to arrive.
/:cl: