### PR TITLE
[Take 50] Makes parsing work

### DIFF
--- a/code/controllers/subsystem/server_maint.dm
+++ b/code/controllers/subsystem/server_maint.dm
@@ -60,5 +60,6 @@ SUBSYSTEM_DEF(server_maint)
 	var/tgsversion = world.TgsVersion()
 	if(tgsversion)
 		SSblackbox.record_feedback("text", "server_tools", 1, tgsversion)
+	parse_server_logs() // KEPLER CHANGE - Parse round logs
 
 #undef PING_BUFFER_TIME

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -232,7 +232,6 @@ GLOBAL_VAR(restart_counter)
 
 	log_world("World rebooted at [TIME_STAMP("hh:mm:ss", FALSE)]")
 	shutdown_logging() // Past this point, no logging procs can be used, at risk of data loss.
-	parse_server_logs() // KEPLER CHANGE - If logs have been closed, parse them now
 	..()
 
 /world/proc/update_status()


### PR DESCRIPTION
## About The Pull Request
This PR moves the end round log parsing call to the `Shutdown()` of `SSserver_maint`. This should hopefully give the parser enough time to carry out its tasks instead of the line before the server is killed, as currently the server can parse `attack.log` and then it kills. This should hopefully give us enough time.

## Why It's Good For The Game
This stuff should actually work, for fucks sake affected do your job

## Changelog
:cl: AffectedArc07
fix: Fixes the log parser. Again.
/:cl:
