### PR TITLE
Makes megafauna gib

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -50,6 +50,10 @@ Difficulty: Very Hard
 	deathmessage = "disintegrates, leaving a glowing core in its wake."
 	death_sound = 'sound/magic/demon_dies.ogg'
 
+/mob/living/simple_animal/hostile/megafauna/colossus/devour(mob/living/L)	
+	visible_message("<span class='colossus'>[src] disintegrates [L]!</span>")	
+	L.dust()
+	
 /mob/living/simple_animal/hostile/megafauna/colossus/OpenFire()
 	anger_modifier = CLAMP(((maxHealth - health)/50),0,20)
 	ranged_cooldown = world.time + 120

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -118,6 +118,15 @@ Difficulty: Normal
 	qdel(spawned_beacon)
 	. = ..()
 
+/mob/living/simple_animal/hostile/megafauna/hierophant/devour(mob/living/L)
+	for(var/obj/item/W in L)
+		if(!L.dropItemToGround(W))
+			qdel(W)
+	visible_message("<span class='hierophant_warning'>\"[pick(kill_phrases)]\"</span>")
+	visible_message("<span class='hierophant_warning'>[src] annihilates [L]!</span>","<span class='userdanger'>You annihilate [L], restoring your health!</span>")
+	adjustHealth(-L.maxHealth*0.5)
+	L.dust()
+
 /mob/living/simple_animal/hostile/megafauna/hierophant/CanAttack(atom/the_target)
 	. = ..()
 	if(istype(the_target, /mob/living/simple_animal/hostile/asteroid/hivelordbrood)) //ignore temporary targets in favor of more permanent targets
@@ -149,6 +158,8 @@ Difficulty: Normal
 				else
 					burst_range = 3
 					INVOKE_ASYNC(src, .proc/burst, get_turf(src), 0.25) //melee attacks on living mobs cause it to release a fast burst if on cooldown
+			else
+				devour(L)
 		else
 			return ..()
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -77,6 +77,26 @@
 	else
 		..()
 
+/mob/living/simple_animal/hostile/megafauna/AttackingTarget()	
+	if(recovery_time >= world.time)	
+		return	
+	. = ..()	
+	if(. && isliving(target))	
+		var/mob/living/L = target	
+		if(L.stat != DEAD)	
+			if(!client && ranged && ranged_cooldown <= world.time)	
+				OpenFire()	
+		else	
+			devour(L)
+
+/mob/living/simple_animal/hostile/megafauna/proc/devour(mob/living/L)	
+	if(!L)	
+		return	
+	visible_message("<span class='danger'>[src] devours [L]!</span>", "<span class='userdanger'>You feast on [L], restoring your health!</span>")	
+	if(!is_station_level(z) || client) //NPC monsters won't heal while on station	
+		adjustBruteLoss(-L.maxHealth/2)	
+	L.gib()
+
 /mob/living/simple_animal/hostile/megafauna/ex_act(severity, target)
 	switch (severity)
 		if (1)


### PR DESCRIPTION
## About The Pull Request
Fixes #237
Megafauna now gib you when youre dead. The proc for this is named `devour()`, so I associated it with the V-word. `Devour` is the word that TG uses, so its staying for the sake of modularity

## Why It's Good For The Game
Megafauna now perform as intended, and logs dont get spammed

## Changelog
:cl: AffectedArc07
fix: Megafauna gib again
/:cl:
