### PR TITLE
Makes combat mode mouse looking work again

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -440,7 +440,7 @@
 
 
 //Hook for running code when a dir change occurs
-/atom/proc/setDir(newdir)
+/atom/proc/setDir(newdir, ismousemovement=FALSE)
 	SEND_SIGNAL(src, COMSIG_ATOM_DIR_CHANGE, dir, newdir)
 	dir = newdir
 

--- a/modular_citadel/code/_onclick/click.dm
+++ b/modular_citadel/code/_onclick/click.dm
@@ -80,22 +80,22 @@
 	var/dy = A.y - y
 	if(!dx && !dy) // Wall items are graphically shifted but on the floor
 		if(A.pixel_y > 16)
-			setDir(NORTH)
+			setDir(NORTH, ismousemovement = TRUE)
 		else if(A.pixel_y < -16)
-			setDir(SOUTH)
+			setDir(SOUTH, ismousemovement = TRUE)
 		else if(A.pixel_x > 16)
-			setDir(EAST)
+			setDir(EAST, ismousemovement = TRUE)
 		else if(A.pixel_x < -16)
-			setDir(WEST)
+			setDir(WEST, ismousemovement = TRUE)
 		return
 
 	if(abs(dx) < abs(dy))
 		if(dy > 0)
-			setDir(NORTH)
+			setDir(NORTH, ismousemovement = TRUE)
 		else
-			setDir(SOUTH)
+			setDir(SOUTH, ismousemovement = TRUE)
 	else
 		if(dx > 0)
-			setDir(EAST)
+			setDir(EAST, ismousemovement = TRUE)
 		else
-			setDir(WEST)
+			setDir(WEST, ismousemovement = TRUE)


### PR DESCRIPTION
## About The Pull Request
Fixes #382

Moving your mouse pointer around now makes your character look in that direction. This broke when making us dreamchecker compatible, and required some proc overriding to make it work

## Why It's Good For The Game
Intended features should work

## Changelog
:cl: AffectedArc07
fix: When in combat mode, your character faces your mouse cursor again
/:cl:
