### PR TITLE
Tweaks Radiation Storms

### DIFF
--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -47,7 +47,9 @@
 /datum/weather/rad_storm/end()
 	if(..())
 		return
-	priority_announce("The radiation threat has passed. Please return to your workplaces.", "Anomaly Alert")
+	priority_announce("The radiation threat has passed. Please return to your workplaces. Maintenance will lose emergency access shortly", "Anomaly Alert")
+	spawn(300) // Give them 30 seconds to get their asses out
+		revoke_maint_all_access()
 	status_alarm(FALSE)
 
 /datum/weather/rad_storm/proc/status_alarm(active)	//Makes the status displays show the radiation warning for those who missed the announcement.

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -55,6 +55,7 @@
 	return TRUE
 
 /datum/round_event_control/proc/preRunEvent()
+	return EVENT_READY
 	if(!ispath(typepath, /datum/round_event))
 		return EVENT_CANT_RUN
 

--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -12,7 +12,9 @@
 	announceWhen	= 1
 
 /datum/round_event/radiation_storm/announce(fake)
+	// I know this has no fake triggers, but I removed fake events
 	priority_announce("High levels of radiation detected near the station. Maintenance is best shielded from radiation.", "Anomaly Alert", 'sound/ai/radiation.ogg')
+	make_maint_all_access()
 	//sound not longer matches the text, but an audible warning is probably good
 
 /datum/round_event/radiation_storm/start()


### PR DESCRIPTION
## About The Pull Request

Fixes #550 

This PR tweaks radiation storms, making them more suited for out population levels.
![image](https://user-images.githubusercontent.com/25063394/64080059-860cac80-cce7-11e9-8a05-99f64c30b4a1.png)
_When the storm starts, maintenance airlocks are opened so anyone trapped can get into safety_

![image](https://user-images.githubusercontent.com/25063394/64080065-93c23200-cce7-11e9-8c36-29b31e84c685.png)
_When the event ends, people are given 30 seconds to leave maintenance before it goes back to how it was_

## Why It's Good For The Game
In this population size, and with nobody sat in the bridge, maintenance isnt opened for radiation storms, which has lead to people dying.

## Changelog
:cl: AffectedArc07
tweak: Radiation storms now give maintenance emergency access
/:cl:
