### PR TITLE
Antag Picking Tweaks

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -272,14 +272,14 @@ SUBSYSTEM_DEF(ticker)
 		message_admins("<span class='notice'>DEBUG: Bypassing prestart checks...</span>")
 
 	CHECK_TICK
-	/*if(hide_mode) CIT CHANGE - comments this section out to obfuscate gamemodes. Quit self-antagging during extended just because "hurrrrr no antaggs!!!!!! i giv sec thing 2 do!!!!!!!!!" it's bullshit and everyone hates it
+	if(hide_mode)
 		var/list/modes = new
 		for (var/datum/game_mode/M in runnable_modes)
 			modes += M.name
 		modes = sortList(modes)
 		to_chat(world, "<b>The gamemode is: secret!\nPossibilities:</B> [english_list(modes)]")
 	else
-		mode.announce()*/
+		mode.announce()
 
 	if(!CONFIG_GET(flag/ooc_during_round))
 		toggle_ooc(FALSE) // Turn it off

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -350,8 +350,8 @@
 /datum/game_mode/proc/get_players_for_role(role)
 	var/list/players = list()
 	var/list/candidates = list()
-	//var/list/drafted = list() Kepler Change | Remove Drafting
-	var/datum/mind/applicant = null
+	//var/list/drafted = list() | Kepler Change: Remove Drafting
+	//var/datum/mind/applicant = null | Kepler Change: Remove Drafting
 
 	// Ultimate randomizing code right here
 	for(var/mob/dead/new_player/player in GLOB.player_list)
@@ -420,8 +420,8 @@
 			break
 	*/
 
-	caniddates = shuffle(candidates) // Lets shuffle, just one last time
-	
+	candidates = shuffle(candidates) // Lets shuffle, just one last time
+
 	return candidates		// Returns: The number of people who had the antagonist role set to yes, regardless of recomended_enemies, if that number is greater than recommended_enemies
 							//			recommended_enemies if the number of people with that role set to yes is less than recomended_enemies,
 							//			Less if there are not enough valid players in the game entirely to make recommended_enemies.

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -350,7 +350,7 @@
 /datum/game_mode/proc/get_players_for_role(role)
 	var/list/players = list()
 	var/list/candidates = list()
-	var/list/drafted = list()
+	//var/list/drafted = list() Kepler Change | Remove Drafting
 	var/datum/mind/applicant = null
 
 	// Ultimate randomizing code right here
@@ -375,6 +375,7 @@
 				if(player.assigned_role == job)
 					candidates -= player
 
+	/* KEPLER CHANGE: Remove antag drafting. If someone doesnt want to be antag, why are we lumping them into it.
 	if(candidates.len < recommended_enemies)
 		for(var/mob/dead/new_player/player in players)
 			if(player.client && player.ready == PLAYER_READY_TO_PLAY)
@@ -417,7 +418,10 @@
 
 		else												// Not enough scrubs, ABORT ABORT ABORT
 			break
+	*/
 
+	caniddates = shuffle(candidates) // Lets shuffle, just one last time
+	
 	return candidates		// Returns: The number of people who had the antagonist role set to yes, regardless of recomended_enemies, if that number is greater than recommended_enemies
 							//			recommended_enemies if the number of people with that role set to yes is less than recomended_enemies,
 							//			Less if there are not enough valid players in the game entirely to make recommended_enemies.


### PR DESCRIPTION
## About The Pull Request

Fixes #467 

This PR makes it so you can no longer be drafted into antag roles with your preference off, and so it actually shows what mode it is.

## Why It's Good For The Game
We should be respecting preferences. What is the point of an antag preference if it means nothing.

## Changelog
:cl: AffectedArc07
tweak: You can no longer be drafted into antagonist roles with the preference off
tweak: It now displays what the roundtype is (Usually secret)
/:cl:
