### PR TITLE
Makes all autodrobes all access

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -12236,7 +12236,7 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "aCh" = (
-/obj/machinery/vending/autodrobe,
+/obj/machinery/vending/autodrobe/all_access,
 /turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
@@ -42629,11 +42629,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/medical/virology)
-"bWk" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "bWl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -56667,9 +56662,6 @@
 /obj/item/stock_parts/cell/high,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"evR" = (
-/turf/open/floor/plating,
-/area/maintenance/bar)
 "eyM" = (
 /obj/machinery/mineral/ore_redemption{
 	input_dir = 2;
@@ -57193,7 +57185,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "nfm" = (
-/obj/machinery/vending/autodrobe,
+/obj/machinery/vending/autodrobe/all_access,
 /turf/open/floor/wood,
 /area/maintenance/bar)
 "noK" = (
@@ -57354,12 +57346,6 @@
 	},
 /turf/open/floor/plating,
 /area/construction)
-"rMN" = (
-/obj/structure/bed,
-/obj/item/tank/internals/anesthetic,
-/obj/item/clothing/mask/breath,
-/turf/open/floor/plating,
-/area/maintenance/bar)
 "rNc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -20186,7 +20186,6 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aOx" = (
-/obj/machinery/vending/autodrobe,
 /obj/structure/cable/white{
 	icon_state = "0-2"
 	},
@@ -20209,6 +20208,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/vending/autodrobe/all_access,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aOy" = (
@@ -24706,12 +24706,12 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/theatre)
 "aVj" = (
-/obj/machinery/vending/autodrobe,
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -22
 	},
 /obj/machinery/light,
+/obj/machinery/vending/autodrobe/all_access,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/theatre)
 "aVk" = (
@@ -110982,12 +110982,10 @@
 /turf/open/floor/plating,
 /area/crew_quarters/theatre/abandoned)
 "dFl" = (
-/obj/machinery/vending/autodrobe{
-	req_access_txt = "0"
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/vending/autodrobe/all_access,
 /turf/open/floor/plating,
 /area/crew_quarters/theatre/abandoned)
 "dFm" = (
@@ -127181,9 +127179,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"nyN" = (
-/turf/open/floor/plating,
-/area/crew_quarters/abandoned_gambling_den)
 "nSh" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /turf/closed/wall/r_wall,
@@ -127535,10 +127530,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
-"vhA" = (
-/obj/item/clothing/under/color/grey,
-/turf/open/floor/plating,
-/area/crew_quarters/abandoned_gambling_den)
 "vAb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -46445,7 +46445,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "bLS" = (
-/obj/machinery/vending/autodrobe,
+/obj/machinery/vending/autodrobe/all_access,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "bLT" = (

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -15949,7 +15949,6 @@
 	},
 /area/crew_quarters/theatre)
 "aBX" = (
-/obj/machinery/vending/autodrobe,
 /obj/structure/cable/white{
 	icon_state = "0-2"
 	},
@@ -15976,6 +15975,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/vending/autodrobe/all_access,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
 "aBY" = (
@@ -17480,9 +17480,6 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "aEN" = (
-/obj/machinery/vending/autodrobe{
-	req_access_txt = "0"
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 26
 	},
@@ -17501,6 +17498,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/vending/autodrobe/all_access,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "aEO" = (
@@ -30026,15 +30024,13 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "bbn" = (
-/obj/machinery/vending/autodrobe{
-	req_access_txt = "0"
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/vending/autodrobe/all_access,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port)
 "bbp" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -19803,10 +19803,10 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
 "aVm" = (
-/obj/machinery/vending/autodrobe,
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
 	},
+/obj/machinery/vending/autodrobe/all_access,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
 "aVn" = (


### PR DESCRIPTION
## About The Pull Request
This PR modifies all on map autodrobes to the varient which require no access. This means that the mime/clown autodrobes can be accessed by anyone, but that still requires a breakin.

Fixes #549

## Why It's Good For The Game
People should be able to use things

## Changelog
:cl: AffectedArc07
tweak: Autodrobes can now be used by anyone, instead of just clown/mime
/:cl:
