### PR TITLE
Who verb mentor color

### DIFF
--- a/modular_citadel/code/modules/client/verbs/who.dm
+++ b/modular_citadel/code/modules/client/verbs/who.dm
@@ -28,6 +28,8 @@
 	set category = "OOC"
 
 	var/msg = ""
+	var/a_col = "#FF0000" //Admin color
+	var/m_col = "#12A5F4" //Mentor color
 
 	var/list/Lines = list()
 	var/list/assembled = list()
@@ -36,7 +38,7 @@
 		log_admin("[key_name(usr)] checked advanced who in-round")
 
 	// KEPLER CHANGE: Make admins and mentors highlight instead of being in their own categoriess
-	Lines += "<b>Players | <font color='#FF0000'>Admins</font> | <font color='#0033CC'>Mentors</font></b>"
+	Lines += "<b>Players | <font color='[a_col]'>Admins</font> | <font color='[m_col]'>Mentors</font></b>"
 	for(var/X in sortKey(GLOB.clients))
 		var/client/C = X
 		if(!C)
@@ -45,9 +47,9 @@
 		if(C.holder && C.holder.fakekey)
 			key = C.holder.fakekey
 		if(C.holder)
-			key = "<font color='#FF0000'>[key]</font>"
+			key = "<font color='[a_col]'>[key]</font>"
 		else if(C in GLOB.mentors)
-			key = "<font color='#0033CC'>[key]</font>"
+			key = "<font color='[m_col]'>[key]</font>"
 		assembled += "\t [key][admin_mode? "[show_admin_info(C)]":""] ([round(C.avgping, 1)]ms)"
 	Lines += jointext(assembled, "\n")
 	


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the `who` verb compatible with darkmode. You should now be able to see the names of mentors without ruining your eyes.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Being able to see text easily is good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: The color of mentors have been changed lightly in the "who" verb.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
