### PR TITLE
Reverts Xenobio Goldslime Spawn not able to spawn headcrabs

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -22,7 +22,7 @@
 	ventcrawler = VENTCRAWLER_ALWAYS
 	var/datum/mind/origin
 	var/egg_lain = 0
-	gold_core_spawnable = NO_SPAWN //are you sure about this?? // CITADEL CHANGE, Yes.
+	gold_core_spawnable = HOSTILE_SPAWN
 
 /mob/living/simple_animal/hostile/headcrab/proc/Infect(mob/living/carbon/victim)
 	var/obj/item/organ/body_egg/changeling_egg/egg = new(victim)


### PR DESCRIPTION
Reverts an "Anti Powergaming PR" from Citadel. Why? Xenolings is basicly an endgame goal so to say for Xenobiology. It takes alot of effort to: 1) Get gold slimes to spawn the headcrab from a vast spawnpool. 2) Get the Corpse for the headcrab to infect (Can be substituted by your former self since headcrabs can indeed attack). 3) Get rainbow slimes (100 Mutate chance from any other slime, requires mutation potions from red) for the concious transfer potion. 

Additionally Xenolings are still changelings. They are not antag for a matter of fact but will still get slain even if they announce that they are turned into a ling and takes an entire shift to get which could be spend in more useful extracts, specially since the crossbreed extracts are in.

Why It's Good For The Game:

Gives Xenobiology another endgame goal. Its all about slimes right now. Xenolings are transhumanism sort of. Like genetics but in a different way. Could be interesting.


## Changelog
:cl:
add: Xenolings are back.
/:cl:


