### PR TITLE
Removes Fly Person teleport

### DIFF
--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -68,14 +68,16 @@
 	if (ismovableatom(M))
 		if(do_teleport(M, com.target, channel = TELEPORT_CHANNEL_BLUESPACE))
 			use_power(5000)
-
-			if(!calibrated && iscarbon(M) && prob(0 - ((accurate) * 0))) //oh dear a problem
+			
+			/*KEPLER CHANGE: Removes flyperson chance
+			if(!calibrated && iscarbon(M) && prob(30 - ((accurate) * 10))) //oh dear a problem
 				var/mob/living/carbon/C = M
 				if(C.dna?.species && C.dna.species.id != "fly" && !HAS_TRAIT(C, TRAIT_RADIMMUNE))
 					to_chat(C, "<span class='italics'>You hear a buzzing in your ears.</span>")
 					C.set_species(/datum/species/fly)
 					log_game("[C] ([key_name(C)]) was turned into a fly person")
-					C.apply_effect((rand(0 - accurate * 0, 0 - accurate * 0)), EFFECT_IRRADIATE, 0)
+					C.apply_effect((rand(120 - accurate * 40, 180 - accurate * 60)), EFFECT_IRRADIATE, 0)
+			*/
 
 			calibrated = FALSE
 	return

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -69,13 +69,13 @@
 		if(do_teleport(M, com.target, channel = TELEPORT_CHANNEL_BLUESPACE))
 			use_power(5000)
 
-			if(!calibrated && iscarbon(M) && prob(30 - ((accurate) * 10))) //oh dear a problem
+			if(!calibrated && iscarbon(M) && prob(0 - ((accurate) * 0))) //oh dear a problem
 				var/mob/living/carbon/C = M
 				if(C.dna?.species && C.dna.species.id != "fly" && !HAS_TRAIT(C, TRAIT_RADIMMUNE))
 					to_chat(C, "<span class='italics'>You hear a buzzing in your ears.</span>")
 					C.set_species(/datum/species/fly)
 					log_game("[C] ([key_name(C)]) was turned into a fly person")
-					C.apply_effect((rand(120 - accurate * 40, 180 - accurate * 60)), EFFECT_IRRADIATE, 0)
+					C.apply_effect((rand(0 - accurate * 0, 0 - accurate * 0)), EFFECT_IRRADIATE, 0)
 
 			calibrated = FALSE
 	return


### PR DESCRIPTION
## About The Pull Request?

Quick and dirty way to make sure fly persons only occur as rare events, e.g. someone using the mirror of pride or a wizard using.. well their mirror of pride. The notion of teleportation malfunctioning in that memy way is very LRP, almost as bad as neon green colored clown transformation Wizards possess on some servers. Teleporters can already malfunction and teleport you to wrong destinations despite being callibrated which is much more severe of a punishment/drawback for overusing a teleporter and most importantly doesnt nearly break "immursion" and RP, let alone the fact that teleportation would not work that way, its not some childs card game card that lets you fuse two creatures.

## How is it done?

Setting the probability of the event to fire to 0. 0 times something equals zero. Therefor the event should not fire at all. I mean.. one could probably just erase the lines that let the event happen in the first place.. *shrug


## Why It's Good For The Game

No more polymerisation card draw when teleporting. No more flyperson transformation on teleport. There are dozents of possible disadvantages one could get from teleporting that would make sense and are not Goon Tier LRP. Being turned into a fly person is not one of them.

## Changelog
:cl:
tweak: Flyperson transformation on teleport has been changed to a probability of zero.
/:cl:

