### PR TITLE
custom emote in say tweak

### DIFF
--- a/modular_citadel/code/modules/mob/mob.dm
+++ b/modular_citadel/code/modules/mob/mob.dm
@@ -2,15 +2,15 @@
 	return
 
 /mob/say_mod(input, message_mode)
-	var/customsayverb = findtext(input, "*")
+	var/customsayverb = findtext(input, "!", 1, 2) //KEPLER EDIT: makes starting Say with '!' output everything after it as emote, instead of the weird '*'
 	if(customsayverb)
-		return lowertext(copytext(input, 1, customsayverb))
+		return lowertext(copytext(input, customsayverb+1))
 	. = ..()
 
 /atom/movable/proc/attach_spans(input, list/spans)
-	var/customsayverb = findtext(input, "*")
+	var/customsayverb = findtext(input, "!", 1, 2)
 	if(customsayverb)
-		input = capitalize(copytext(input, customsayverb+1))
+		return //END KEPLER EDIT
 	if(input)
 		return "[message_spans_start(spans)][input]</span>"
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You can now use `!` at the start of your `Say` message to emote everything after it.
`say "!burps loudly"` -> prints the message `burps loudly` like a normal emote
`say ";!screams"` -> prints the message `screams` over the radio, and to those around you.
`say ".s !screams"` -> same as above, but on the security channel.

The custom emote functionality of `*` has been removed.

Fixes #589
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Keep it simple, keep it nice.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: using '!' at the start of Say now emotes everything after it, instead of '*'.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
