### PR TITLE
quirk blood checking

### DIFF
--- a/code/datums/traits/_quirk.dm
+++ b/code/datums/traits/_quirk.dm
@@ -10,6 +10,7 @@
 	var/medical_record_text //This text will appear on medical records for the trait. Not yet implemented
 	var/mood_quirk = FALSE //if true, this quirk affects mood and is unavailable if moodlets are disabled
 	var/mob_trait //if applicable, apply and remove this mob trait
+	var/needs_blood = FALSE //if true, locks out species with NOBLOOD and exotic_blood in the quirk menu
 	var/mob/living/quirk_holder
 
 /datum/quirk/New(mob/living/quirk_mob, spawn_effects)

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -7,13 +7,10 @@
 	gain_text = "<span class='danger'>You feel your vigor slowly fading away.</span>"
 	lose_text = "<span class='notice'>You feel vigorous again.</span>"
 	medical_record_text = "Patient requires regular treatment for blood loss due to low production of blood."
+	needs_blood = TRUE
 
 /datum/quirk/blooddeficiency/on_process()
-	var/mob/living/carbon/human/H = quirk_holder
-	if(NOBLOOD in H.dna.species.species_traits) //can't lose blood if your species doesn't have any
-		return
-	else
-		quirk_holder.blood_volume -= 0.275
+	quirk_holder.blood_volume -= 0.275
 
 /datum/quirk/depression
 	name = "Depression"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1003,6 +1003,13 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			if(initial(T.mood_quirk) && CONFIG_GET(flag/disable_human_mood))
 				lock_reason = "Mood is disabled."
 				quirk_conflict = TRUE
+			if(initial(T.needs_blood))
+				if(NOBLOOD in pref_species.species_traits)
+					lock_reason = "Your species has no blood."
+					quirk_conflict = TRUE
+				if(pref_species.exotic_blood)
+					lock_reason = "Your species does not have normal blood."
+					quirk_conflict = TRUE
 			if(has_quirk)
 				if(quirk_conflict)
 					all_quirks -= quirk_name


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Acute Blood Deficiency is no longer choosable by any species with the `NOBLOOD` flag or `exotic_blood` variable, in the character creation quirk menu.
Fixes #259
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Free quirk points is bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Species like plasmaman and slimepeople can no longer choose Acute Blood Deficiency for free quirk points.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
