### PR TITLE
Tweaks assembly logging

### DIFF
--- a/code/modules/integrated_electronics/subtypes/output.dm
+++ b/code/modules/integrated_electronics/subtypes/output.dm
@@ -241,9 +241,9 @@
 		var/sanitized_text = sanitize(text)
 		A.say(sanitized_text)
 		if (assembly)
-			log_say("[assembly] [REF(assembly)] : [sanitized_text]")
+			log_game("[assembly] [REF(assembly)] SAY: [sanitized_text]")
 		else
-			log_say("[name] ([type]) : [sanitized_text]")
+			log_game("[name] ([type]) SAY: [sanitized_text]")
 
 /obj/item/integrated_circuit/output/video_camera
 	name = "video camera circuit"


### PR DESCRIPTION
## About The Pull Request
Makes assemblies speech file under game logging instead of say, because it doesnt fix that format

## Why It's Good For The Game
Makes me not have to code snowflake cases into my parser

## Changelog
:cl: AffectedArc07
server: Assembly speech logs are now under game logs not say logs
/:cl:
