### PR TITLE
Fixes non-silicons being able to beep

### DIFF
--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -82,6 +82,13 @@
 	key_third_person = "boops"
 	message = "boops."
 
+/datum/emote/sound/silicon/beep
+	key = "beep"
+	key_third_person = "beeps"
+	message = "beeps."
+	message_param = "beeps at %t."
+	sound = 'sound/machines/twobeep.ogg'
+
 /datum/emote/sound/silicon/buzz
 	key = "buzz"
 	key_third_person = "buzzes"
@@ -723,14 +730,6 @@
 
 	to_chat(user, message)
 
-/datum/emote/sound/beep
-	key = "beep"
-	key_third_person = "beeps"
-	message = "beeps."
-	message_param = "beeps at %t."
-	sound = 'sound/machines/twobeep.ogg'
-	mob_type_allowed_typecache = list(/mob/living/brain, /mob/living/silicon, /mob/living/carbon/human)
-
 /datum/emote/living/circle
 	key = "circle"
 	key_third_person = "circles"
@@ -1056,6 +1055,13 @@ IPC
 	mob_type_allowed_typecache = list(/mob/living/carbon/human)
 	emote_type = EMOTE_AUDIBLE
 	restricted_species = list(SPECIES_ID_IPC) // For when we implement IPC
+
+/datum/emote/sound/ipc/beep
+	key = "beep"
+	key_third_person = "beeps"
+	message = "beeps."
+	message_param = "beeps at %t."
+	sound = 'sound/machines/twobeep.ogg'
 
 /datum/emote/sound/ipc/buzz
 	key = "buzz"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes an issue where humans were able to use the beep emote.
Fixes #815 

## Why It's Good For The Game

Humans cannot beep.

## Changelog
:cl:
fix: Humans can no longer beep.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
