### PR TITLE
Fixes widescreen for now

### DIFF
--- a/code/modules/tooltip/tooltip.html
+++ b/code/modules/tooltip/tooltip.html
@@ -122,8 +122,8 @@
 				//Get the real icon size according to the client view
 				var mapWidth 		= map['view-size'].x,
 					mapHeight 		= map['view-size'].y,
-					tilesShown 		= tooltip.client_view_w
-					realIconSize 	= mapWidth / tilesShown,
+					tilesShown 		= tooltip.client_view_h
+					realIconSize 	= mapHeight / tilesShown,
 					resizeRatio		= realIconSize / tooltip.tileSize,
 					//Calculate letterboxing offsets	
 					leftOffset 		= (map.size.x - mapWidth) / 2,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This should fix widescreen, *for now*.
A better solution would be to make this whole thing calculate off both width and height, instead of just one of them. However, im happy with this for now.
Fixes: #236
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Tooltips should know their place!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Tooltips in widescreen mode has been fixed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
