### PR TITLE
Adds a verb to force recreate the chat object

### DIFF
--- a/modular_kepler/code/modules/client/verbs/ooc.dm
+++ b/modular_kepler/code/modules/client/verbs/ooc.dm
@@ -1,0 +1,16 @@
+
+/client/verb/force_fix_chat()
+	set name = "Force Recreate Chat"
+	set category = "OOC"
+	var/action = alert(src, "This will force recreate your chat, completley destroying the object and remaking it.\nAre you sure? (All chat history will be lost)", "Warning", "Yes", "No")
+	if(action != "Yes")
+		return
+	// Now we only process if Yes is pressed
+	// Nuke old chat objects
+	winset(src, "output", "is-visible=true;is-disabled=false")
+	winset(src, "browseroutput", "is-visible=false")
+	chatOutput.loaded = FALSE
+	// Now make a new one
+	chatOutput.start()
+	chatOutput.load()
+	alert(src, "Your chat has been force recreated. If this still hasnt fixed issues, please make an issue report, with your BYOND version, Windows version, and IE Version", "Done", "Ok")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3084,6 +3084,7 @@
 #include "modular_kepler\code\game\objects\ids.dm"
 #include "modular_kepler\code\game\objects\items\cards_ids.dm"
 #include "modular_kepler\code\modules\client\preferences.dm"
+#include "modular_kepler\code\modules\client\verbs\ooc.dm"
 #include "modular_kepler\code\modules\mob\dead\new_player\tos_procs.dm"
 #include "modular_kepler\code\modules\oracle_ui\assets.dm"
 #include "modular_kepler\code\modules\oracle_ui\hookup_procs.dm"


### PR DESCRIPTION
## About The Pull Request
This PR adds in a verb which will hard delete a chat object then force recreate it. Sometimes fancy chat fails to load until I manually do the following long-winded procedure:

Fix Chat > Force Reload > Didnt Work > Didnt Work Again > Switch To Old Chat
Fix Chat > Force Reload > Done

This PR adds a verb which does the required steps in less than a second

## Why It's Good For The Game
I should be able to recreate my chat object without having to spend 20 seconds doing it

## Changelog
:cl: AffectedArc07
add: There is now a verb to force-recreate your chat object
/:cl:
