### PR TITLE
Tweaks our gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,10 @@ tools/MapAtmosFixer/MapAtmosFixer/bin/*
 #extra map stuff
 /_maps/**/backup/
 /_maps/templates.dm
+
+# KEPLER CHANGES
+/tools/dmitool/bin/
+/tools/dmitool/.gradle/
+/tools/dmitool/.settings/
+/tools/dmitool/.classpath
+/tools/dmitool/.project


### PR DESCRIPTION
## About The Pull Request
This tweaks our `gitignore` file to not show build from `DMITool`

## Why It's Good For The Game
I shouldnt have to deal with 26 uneeded files in my working tree, which my langservers compiled and I had no interaction in making
![image](https://user-images.githubusercontent.com/25063394/68505516-4de19700-025f-11ea-8b7c-62ecb201ce9a.png)

## Changelog
:cl:
tweak: The gitignore file now ignores compiled DMITool
/:cl:
