### PR TITLE
Adds in a chem dispenser to xenobiology

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -38576,9 +38576,8 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bMq" = (
-/obj/structure/closet/l3closet/scientist,
-/obj/item/extinguisher,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/chem_dispenser,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bMr" = (


### PR DESCRIPTION
## About The Pull Request
This PR adds a chem dispenser to xenobiology, which is required in this population set due to chemistry almost never being available.

MapDiffBot should generate the images

## Why It's Good For The Game
Allows xenobio people to actually do stuff

## Changelog
:cl:
tweak: Xenobio has a chem dispenser now
/:cl:
